### PR TITLE
Bugfix diff action

### DIFF
--- a/manifests/diff/diff.sh
+++ b/manifests/diff/diff.sh
@@ -32,7 +32,7 @@ generate_diff_output() {
                 output+=$'\n'
             fi
         done < <(find "$dir" -type f -print0 | sort -z)
-    done < <(find "${INPUTS_PATH}" -type d -name "$pattern" -print0 | sort -z)
+    done < <(find "${INPUTS_PATH}" -maxdepth 1 -type d -name "$pattern" -print0 | sort -z)
 
     echo "$output"
 }

--- a/manifests/diff/test-env/test-dev/namespace-dev/manifest.jsonnet
+++ b/manifests/diff/test-env/test-dev/namespace-dev/manifest.jsonnet
@@ -1,0 +1,11 @@
+{
+  apiVersion: 'skiperator.kartverket.no/v1alpha1',
+  kind: 'Application',
+  metadata: {
+    name: 'test-dev-dev',
+  },
+  spec: {
+    image: 'test-duplicate',
+    port: 3000,
+  },
+}


### PR DESCRIPTION
The previous implementation looked recursively for manifest folders with `-dev` or `-prod` suffixes. This PR fixes this with only seaching for these folders 1 level deep. Also the script is rewritten in python for readability and maintainability. Tests are also updated.

**How to test**
- Pull branch
- Change the jsonnet file: `manfiests/diff/test-env/test-dev/namespace-dev/manifest.jsonnet`
- run the `./test.sh` script
- output should only give one diff for this file.