### PR TITLE
🐛 Fix invalids check

### DIFF
--- a/manifests/diff/diff.sh
+++ b/manifests/diff/diff.sh
@@ -56,7 +56,7 @@ while IFS= read -r dir; do
 done < <(find "${INPUTS_PATH}" -maxdepth 1 -mindepth 1 -type d)
 
 # Prompt the invalid suffixes so the user can fix them. The correct format is dash suffixes
-if [[ ${#invalids[@]i} -gt 0 ]];then
+if [[ ${#invalids[@]} -gt 0 ]];then
     echo "WARNING: Found invalid cluster name(s):"
     for invalid in "${invalids[@]}"; do
          echo "'${invalid}' is invalid (skipped)"


### PR DESCRIPTION
## Description 📝
The error `./diff.sh: line 59: ${#invalids[@]i}: bad substitution` occurred in some environments running the `diff.sh` script.

## Motivation and Context 💡
When testing locally the error was not caught, because of different `bash` versions. In local development we ran bash 3.2, while others run a newer version, like bash 5.2. 

## How Has This Been Tested? 🧪
- Upgraded bash and tested the `test.sh`.
- Ran the script in a workflow  

## Types of changes 🔄
- [x] Bug fix (non-breaking change which fixes an issue) 🐛

## Checklist: ✅
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. 💅
- [x] My changes do not break the existing tests 🧪