### PR TITLE
Opa composite actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 /.security/ @omaen
+/opa/ @kartverket/tilgangsstyring
+/.github/workflows/test-opa.yml @kartverket/tilgangsstyring

--- a/.github/workflows/test-opa.yml
+++ b/.github/workflows/test-opa.yml
@@ -1,0 +1,259 @@
+name: test-opa
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'opa/**'
+      - '.github/workflows/test-opa.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'opa/**'
+      - '.github/workflows/test-opa.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # Builds the testdata policies and verifies that:
+  #   - the bundle file is produced at the expected path,
+  #   - test files (`*_test.rego`) are excluded from the bundle,
+  #   - production policy files are present in the bundle.
+  build-push-happy-path:
+    name: 'build-push: build only (push=false)'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
+        with:
+          version: '1.16.2'
+
+      - id: build
+        uses: ./opa/build-push
+        with:
+          rego-path: opa/build-push/testdata/policies
+          push: 'false'
+
+      - name: Verify bundle output
+        env:
+          BUNDLE_PATH: ${{ steps.build.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f "$BUNDLE_PATH" ]]; then
+            echo "::error::Bundle was not produced at $BUNDLE_PATH"
+            exit 1
+          fi
+
+          contents=$(tar -tzf "$BUNDLE_PATH")
+          echo "Bundle contents:"
+          echo "$contents"
+
+          # Test files must be excluded by the action's --ignore '*_test.rego'.
+          if echo "$contents" | grep -q '_test\.rego$'; then
+            echo "::error::Test files leaked into bundle"
+            exit 1
+          fi
+
+          # Production policies must be present.
+          for required in main.rego helpers.rego; do
+            if ! echo "$contents" | grep -q "$required"; then
+              echo "::error::Expected $required in bundle, but it was missing"
+              exit 1
+            fi
+          done
+
+  # Verifies the action fails fast (with the expected error) when `rego-path`
+  # doesn't exist on disk.
+  build-push-missing-path:
+    name: 'build-push: fails when rego-path missing'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
+        with:
+          version: '1.16.2'
+
+      - id: build
+        uses: ./opa/build-push
+        continue-on-error: true
+        with:
+          rego-path: opa/build-push/testdata/does-not-exist
+          push: 'false'
+
+      - name: Assert the build step failed
+        env:
+          OUTCOME: ${{ steps.build.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected build step to fail, but outcome was '$OUTCOME'"
+            exit 1
+          fi
+
+  # Lints the `clean` testdata fixture — should succeed with zero violations
+  # and produce a regal-results.json with an empty `violations` array.
+  lint-clean:
+    name: 'lint: clean policies pass'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: open-policy-agent/setup-regal@761188c3b435761fa254beca508a44875619648f # v2.0.0
+
+      - id: lint
+        uses: ./opa/lint
+        with:
+          rego-path: opa/lint/testdata/clean
+
+      - name: Verify outputs
+        env:
+          EXIT_CODE: ${{ steps.lint.outputs.exit-code }}
+          RESULTS_FILE: ${{ steps.lint.outputs.results-file }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EXIT_CODE" != "0" ]]; then
+            echo "::error::Expected exit-code 0, got '$EXIT_CODE'"
+            exit 1
+          fi
+
+          violations=$(jq '.violations | length' "$RESULTS_FILE")
+          if [[ "$violations" != "0" ]]; then
+            echo "::error::Expected 0 violations, got $violations"
+            jq '.violations' "$RESULTS_FILE"
+            exit 1
+          fi
+
+  # Lints the `violations` testdata fixture (deliberately badly-formatted Rego)
+  # — should fail with a non-zero exit code and report at least one violation.
+  lint-violations:
+    name: 'lint: violations cause failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: open-policy-agent/setup-regal@761188c3b435761fa254beca508a44875619648f # v2.0.0
+
+      - id: lint
+        uses: ./opa/lint
+        continue-on-error: true
+        with:
+          rego-path: opa/lint/testdata/violations
+
+      - name: Verify the lint step failed and recorded violations
+        env:
+          OUTCOME: ${{ steps.lint.outcome }}
+          EXIT_CODE: ${{ steps.lint.outputs.exit-code }}
+          RESULTS_FILE: ${{ steps.lint.outputs.results-file }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected lint step to fail, got outcome '$OUTCOME'"
+            exit 1
+          fi
+          if [[ "$EXIT_CODE" == "0" ]]; then
+            echo "::error::Expected non-zero exit-code, got '$EXIT_CODE'"
+            exit 1
+          fi
+
+          violations=$(jq '.violations | length' "$RESULTS_FILE")
+          if (( violations < 1 )); then
+            echo "::error::Expected at least one violation, got $violations"
+            exit 1
+          fi
+          echo "Recorded $violations violation(s) as expected."
+
+  # Runs the `passing` testdata fixture — should succeed and report all tests
+  # as passing in the results JSON.
+  test-passing:
+    name: 'test: passing tests succeed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
+        with:
+          version: '1.16.2'
+
+      - id: test
+        uses: ./opa/test
+        with:
+          test-path: opa/test/testdata/passing
+
+      - name: Verify outputs
+        env:
+          EXIT_CODE: ${{ steps.test.outputs.exit-code }}
+          RESULTS_FILE: ${{ steps.test.outputs.results-file }}
+          COVERAGE_FILE: ${{ steps.test.outputs.coverage-file }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EXIT_CODE" != "0" ]]; then
+            echo "::error::Expected exit-code 0, got '$EXIT_CODE'"
+            exit 1
+          fi
+
+          failed=$(jq '[.[] | select(.fail == true)] | length' "$RESULTS_FILE")
+          errored=$(jq '[.[] | select(.error != null)] | length' "$RESULTS_FILE")
+          total=$(jq 'length' "$RESULTS_FILE")
+          if (( total == 0 )); then
+            echo "::error::No tests were reported in $RESULTS_FILE"
+            exit 1
+          fi
+          if (( failed != 0 || errored != 0 )); then
+            echo "::error::Expected all tests to pass; got $failed failed, $errored errored (of $total)"
+            exit 1
+          fi
+
+          if [[ ! -f "$COVERAGE_FILE" ]]; then
+            echo "::error::Coverage file was not produced at $COVERAGE_FILE"
+            exit 1
+          fi
+
+  # Runs the `failing` testdata fixture (an assertion that contradicts the
+  # policy) — should fail with a non-zero exit code and report at least one
+  # failing test.
+  test-failing:
+    name: 'test: failing tests cause failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
+        with:
+          version: '1.16.2'
+
+      - id: test
+        uses: ./opa/test
+        continue-on-error: true
+        with:
+          test-path: opa/test/testdata/failing
+
+      - name: Verify the test step failed and recorded a failing test
+        env:
+          OUTCOME: ${{ steps.test.outcome }}
+          EXIT_CODE: ${{ steps.test.outputs.exit-code }}
+          RESULTS_FILE: ${{ steps.test.outputs.results-file }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected test step to fail, got outcome '$OUTCOME'"
+            exit 1
+          fi
+          if [[ "$EXIT_CODE" == "0" ]]; then
+            echo "::error::Expected non-zero exit-code, got '$EXIT_CODE'"
+            exit 1
+          fi
+
+          failed=$(jq '[.[] | select(.fail == true)] | length' "$RESULTS_FILE")
+          if (( failed < 1 )); then
+            echo "::error::Expected at least one failing test, got $failed"
+            exit 1
+          fi
+          echo "Recorded $failed failing test(s) as expected."

--- a/opa/build-push/README.md
+++ b/opa/build-push/README.md
@@ -1,0 +1,96 @@
+# OPA Build & Push
+
+Builds an OPA bundle (`bundle.tar.gz`) from a Rego directory and pushes it to an
+OCI registry with one or more tags. Test files (`*_test.rego`) are excluded so
+the production bundle stays lean.
+
+## Prerequisites
+
+All three need to be set up earlier in the workflow:
+
+- [`open-policy-agent/setup-opa`](https://github.com/open-policy-agent/setup-opa) — to run `opa build`.
+- [`oras-project/setup-oras`](https://github.com/oras-project/setup-oras) — to push the bundle as an OCI artifact.
+- [`docker/login-action`](https://github.com/docker/login-action) (or equivalent) — to authenticate to the target registry.
+
+## Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `rego-path` | yes |  | Path to the Rego directory to bundle. Resolves relative to the workspace. |
+| `push` | no | `'true'` | If `'true'`, pushes the built bundle to the registry. Set to `'false'` to build only — useful for PR validation where the push happens on merge. |
+| `artifact-name` | conditional |  | Full OCI reference (without tag) to push to. Example: `ghcr.io/kartverket/accesserator/opa-bundle`. Required when `push` is `'true'`. |
+| `additional-tags` | no | `''` | Extra tags to apply, one per line. `sha-<commit>` is always applied in addition to these. Ignored when `push` is `'false'`. |
+| `list-contents` | no | `'true'` | If `'true'`, runs `tar -tzf bundle.tar.gz` after the build so contents appear in the job log. |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `bundle-path` | Path to the local bundle file (always `bundle.tar.gz`). |
+| `digest` | Manifest digest of the pushed bundle (e.g. `sha256:...`). Empty when `push` is `'false'`. |
+| `tags` | Comma-joined list of tags applied to the pushed bundle. Empty when `push` is `'false'`. |
+| `image-ref` | Fully qualified `<artifact-name>@<digest>` reference. Use this for cosign signing or provenance attestation. Empty when `push` is `'false'`. |
+
+## Behavior
+
+- A missing `rego-path` fails fast with a clear error.
+- The bundle is built with `opa build -b <rego-path> --ignore '*_test.rego' -o bundle.tar.gz`.
+- The pushed manifest gets tagged with `sha-<commit>` plus every entry of
+  `additional-tags`. ORAS pushes a single manifest and applies all tags to it.
+- Whitespace inside each `additional-tags` entry is stripped, so YAML block
+  scalars with indentation work cleanly.
+- A step summary is written with `if: always()` showing the image ref and tags
+  on a successful push, or a note that the bundle was built but not pushed
+  otherwise. Visible under "Summary" in the Actions run UI.
+
+## Example
+
+Minimal usage, push to a SHA-only tag:
+
+```yaml
+- uses: open-policy-agent/setup-opa@<sha>
+- uses: oras-project/setup-oras@<sha>
+- uses: docker/login-action@<sha>
+  with:
+    registry: ghcr.io
+    username: ${{ github.actor }}
+    password: ${{ secrets.GITHUB_TOKEN }}
+
+- uses: kartverket/actions/opa/build-push@<sha>
+  with:
+    rego-path: policies
+    artifact-name: ghcr.io/${{ github.repository }}/opa-bundle
+```
+
+With additional tags on pushes to main:
+
+```yaml
+- uses: kartverket/actions/opa/build-push@<sha>
+  with:
+    rego-path: policies
+    artifact-name: ghcr.io/${{ github.repository }}/opa-bundle
+    additional-tags: |
+      ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
+```
+
+Chaining with a cosign signing step:
+
+```yaml
+- uses: kartverket/actions/opa/build-push@<sha>
+  id: build
+  with:
+    rego-path: policies
+    artifact-name: ghcr.io/${{ github.repository }}/opa-bundle
+
+- run: cosign sign --yes --new-bundle-format ${{ steps.build.outputs.image-ref }}
+```
+
+Build-only (PR validation; the push happens on merge):
+
+```yaml
+- uses: kartverket/actions/opa/build-push@<sha>
+  with:
+    rego-path: policies
+    push: ${{ github.event_name != 'pull_request' }}
+    artifact-name: ghcr.io/${{ github.repository }}/opa-bundle
+```

--- a/opa/build-push/action.yml
+++ b/opa/build-push/action.yml
@@ -1,0 +1,147 @@
+name: 'OPA Build and Push'
+description: |
+  Builds an OPA bundle (`bundle.tar.gz`) from a Rego directory and pushes it to
+  an OCI registry with one or more tags. Test files (`*_test.rego`) are excluded
+  so the production bundle stays lean.
+
+  Prerequisites:
+    - OPA must be installed on the runner (`open-policy-agent/setup-opa`).
+    - ORAS must be installed on the runner (`oras-project/setup-oras`).
+    - The runner must already be authenticated to the target registry
+      (`docker/login-action`).
+
+inputs:
+  rego-path:
+    description: |
+      Path to the Rego directory to bundle. Resolves relative to the workspace.
+    required: true
+  push:
+    description: |
+      If `'true'` (default), pushes the built bundle to the registry. Set to
+      `'false'` to build only — useful for PR validation where the push happens
+      on merge.
+    required: false
+    default: 'true'
+  artifact-name:
+    description: |
+      Full OCI reference (without tag) the bundle will be pushed to. Example:
+      `ghcr.io/kartverket/accesserator/opa-bundle`. Required when `push` is `'true'`.
+    required: false
+    default: ''
+  additional-tags:
+    description: |
+      Extra tags to apply to the bundle, one per line. `sha-<commit>` is always
+      applied in addition to these. Ignored when `push` is `'false'`.
+    required: false
+    default: ''
+  list-contents:
+    description: |
+      If `true`, runs `tar -tzf bundle.tar.gz` after the build so the bundle's
+      contents appear in the job log.
+    required: false
+    default: 'true'
+
+outputs:
+  bundle-path:
+    description: 'Path to the local bundle file (always `bundle.tar.gz`).'
+    value: 'bundle.tar.gz'
+  digest:
+    description: 'Manifest digest of the pushed bundle (e.g. `sha256:...`).'
+    value: ${{ steps.push.outputs.digest }}
+  tags:
+    description: 'Comma-joined list of tags applied to the pushed bundle.'
+    value: ${{ steps.push.outputs.tags }}
+  image-ref:
+    description: |
+      Fully qualified `<artifact-name>@<digest>` reference. Use this for
+      cosign signing or provenance attestation.
+    value: ${{ steps.push.outputs.image-ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build OPA bundle
+      shell: bash
+      env:
+        REGO_PATH: ${{ inputs.rego-path }}
+        LIST_CONTENTS: ${{ inputs.list-contents }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! -e "$REGO_PATH" ]]; then
+          echo "::error::rego-path does not exist: $REGO_PATH"
+          exit 1
+        fi
+
+        opa build -b "$REGO_PATH" --ignore '*_test.rego' -o bundle.tar.gz
+
+        if [[ "$LIST_CONTENTS" == "true" ]]; then
+          tar -tzf bundle.tar.gz
+        fi
+
+    - id: push
+      name: Push bundle to registry
+      if: inputs.push == 'true'
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        ADDITIONAL_TAGS: ${{ inputs.additional-tags }}
+        SHA_TAG: sha-${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$ARTIFACT_NAME" ]]; then
+          echo "::error::artifact-name is required when push is 'true'"
+          exit 1
+        fi
+
+        # Build a comma-joined tag list. `sha-<commit>` always goes first; extra
+        # tags are appended in caller-supplied order. Whitespace inside each tag
+        # is stripped so YAML block scalars with indentation work cleanly.
+        tag_list="$SHA_TAG"
+        while IFS= read -r t; do
+          t="${t//[[:space:]]/}"
+          [[ -z "$t" ]] && continue
+          tag_list="${tag_list},${t}"
+        done <<< "$ADDITIONAL_TAGS"
+
+        # ORAS accepts a comma-joined tag list inside the ref (`...:tag1,tag2`)
+        # and applies all of them to the same manifest digest in a single push.
+        digest=$(oras push "${ARTIFACT_NAME}:${tag_list}" \
+          bundle.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip \
+          --format json | jq -r '.digest')
+
+        echo "digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "tags=$tag_list" >> "$GITHUB_OUTPUT"
+        echo "image-ref=${ARTIFACT_NAME}@${digest}" >> "$GITHUB_OUTPUT"
+
+    - name: Write step summary
+      if: always()
+      shell: bash
+      env:
+        PUSH: ${{ inputs.push }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        DIGEST: ${{ steps.push.outputs.digest }}
+        TAGS: ${{ steps.push.outputs.tags }}
+        IMAGE_REF: ${{ steps.push.outputs.image-ref }}
+      run: |
+        {
+          echo "## OPA bundle"
+          echo ""
+          if [[ ! -f bundle.tar.gz ]]; then
+            # Build step failed before producing the tarball.
+            echo "_Bundle was not built._"
+          elif [[ "$PUSH" == "true" && -n "$DIGEST" ]]; then
+            # Pushed successfully — render the full image ref + per-tag list.
+            echo "**Image:** \`${IMAGE_REF}\`"
+            echo ""
+            echo "**Tags:**"
+            IFS=',' read -ra TAG_ARR <<< "$TAGS"
+            for t in "${TAG_ARR[@]}"; do
+              echo "- \`${ARTIFACT_NAME}:${t}\`"
+            done
+          else
+            # Built but not pushed: either push=false or the push step failed.
+            echo "_Bundle was built (\`bundle.tar.gz\`) but not pushed._"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/opa/build-push/testdata/policies/helpers.rego
+++ b/opa/build-push/testdata/policies/helpers.rego
@@ -1,0 +1,5 @@
+package example
+
+admins := {"alice", "bob"}
+
+is_admin(user) if user in admins

--- a/opa/build-push/testdata/policies/main.rego
+++ b/opa/build-push/testdata/policies/main.rego
@@ -1,0 +1,10 @@
+package example
+
+default allow := false
+
+allow if input.user == "alice"
+
+allow if {
+    input.user == "bob"
+    input.method == "GET"
+}

--- a/opa/build-push/testdata/policies/main_test.rego
+++ b/opa/build-push/testdata/policies/main_test.rego
@@ -1,0 +1,11 @@
+package example_test
+
+import data.example
+
+test_alice_allowed if example.allow with input as {"user": "alice"}
+
+test_bob_get_allowed if example.allow with input as {"user": "bob", "method": "GET"}
+
+test_bob_post_denied if not example.allow with input as {"user": "bob", "method": "POST"}
+
+test_stranger_denied if not example.allow with input as {"user": "eve"}

--- a/opa/lint/README.md
+++ b/opa/lint/README.md
@@ -1,0 +1,48 @@
+# OPA Lint
+
+Runs [Regal](https://www.openpolicyagent.org/projects/regal) against a Rego directory (or file),
+captures the results as JSON for downstream consumption (e.g. building a step
+summary), and fails the step on any violations.
+
+## Prerequisites
+
+Regal must already be installed on the runner. Set it up earlier in the workflow
+with [`open-policy-agent/setup-regal`](https://github.com/open-policy-agent/setup-regal).
+
+## Inputs
+
+| Name        | Required | Description                                                                       |
+|-------------|----------|-----------------------------------------------------------------------------------|
+| `rego-path` | yes      | Path to the Rego directory (or file) to lint. Resolves relative to the workspace. |
+
+## Outputs
+
+| Name           | Description                                                                                   |
+|----------------|-----------------------------------------------------------------------------------------------|
+| `results-file` | Path of the Regal JSON report (always `regal-results.json` in the workspace).                 |
+| `exit-code`    | Regal exit code as a string. `"0"` means no violations; non-zero means violations were found. |
+
+The JSON file conforms to Regal's `--format json` schema and includes a
+`violations` array (file, rule, level, description) plus a `summary` block.
+Read it from a later step that builds a markdown table or filters violations by
+severity.
+
+## Behavior
+
+- The action runs Regal twice over the same path: once with `--format json`
+  (output captured to disk), once with default output (streamed to the job log
+  so violations are visible while the run is in progress).
+- A missing path fails fast with a clear error rather than letting Regal
+  produce a confusing message.
+- On violations Regal exits non-zero. The action mirrors that as a step failure
+  via `core.setFailed`, so downstream steps with no explicit `if:` will be
+  skipped. Use `if: always()` on summary or reporting steps that should still run.
+
+## Example
+
+```yaml
+- uses: open-policy-agent/setup-regal@<sha>
+- uses: kartverket/actions/opa/lint@<sha>
+  with:
+    rego-path: policies
+```

--- a/opa/lint/action.yml
+++ b/opa/lint/action.yml
@@ -1,0 +1,72 @@
+name: 'OPA Lint'
+description: |
+  Runs Regal linting against a Rego directory (or file), captures the results
+  as JSON for downstream consumption, writes a step summary, and fails the step
+  on any violations.
+
+  Prerequisite: Regal must already be installed on the runner. Use
+  `open-policy-agent/setup-regal` in the calling workflow before this action.
+
+inputs:
+  rego-path:
+    description: |
+      Path to the Rego directory (or file) to lint. Resolves relative to the
+      workspace.
+    required: true
+
+outputs:
+  results-file:
+    description: 'Path of the Regal JSON results file written to the workspace.'
+    value: 'regal-results.json'
+  exit-code:
+    description: 'Regal exit code (0 = clean, non-zero = violations found).'
+    value: ${{ steps.lint.outputs.exit-code }}
+
+runs:
+  using: composite
+  steps:
+    - id: lint
+      name: Run Regal
+      shell: bash
+      env:
+        REGO_PATH: ${{ inputs.rego-path }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! -e "$REGO_PATH" ]]; then
+          echo "::error::rego-path does not exist: $REGO_PATH"
+          exit 1
+        fi
+
+        # Two runs of regal over the same path:
+        #   1. JSON mode, captured to disk for downstream consumption.
+        #   2. Default (pretty) mode, streamed to the job log live AND captured
+        #      to a file so the summary step can embed it.
+        # `bash -e` would abort on the first non-zero exit, so we capture the
+        # exit code via `||` instead.
+        LINT_EXIT=0
+        regal lint --format json "$REGO_PATH" > regal-results.json || LINT_EXIT=$?
+        regal lint "$REGO_PATH" 2>&1 | tee regal-output.txt || true
+
+        echo "exit-code=$LINT_EXIT" >> "$GITHUB_OUTPUT"
+
+        if [[ "$LINT_EXIT" -ne 0 ]]; then
+          echo "::error::Regal found violations (exit $LINT_EXIT)."
+          exit "$LINT_EXIT"
+        fi
+
+    - name: Write step summary
+      if: always()
+      shell: bash
+      run: |
+        {
+          echo "## OPA lint (Regal)"
+          echo ""
+          if [[ -f regal-output.txt ]]; then
+            echo '```'
+            cat regal-output.txt
+            echo '```'
+          else
+            echo "_Lint did not run._"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/opa/lint/testdata/clean/policy.rego
+++ b/opa/lint/testdata/clean/policy.rego
@@ -1,4 +1,4 @@
-package example
+package clean
 
 default allow := false
 

--- a/opa/lint/testdata/clean/policy.rego
+++ b/opa/lint/testdata/clean/policy.rego
@@ -1,0 +1,5 @@
+package example
+
+default allow := false
+
+allow if input.user == "alice"

--- a/opa/lint/testdata/violations/policy.rego
+++ b/opa/lint/testdata/violations/policy.rego
@@ -1,0 +1,3 @@
+package example
+default allow=false
+allow if input.user=="alice"

--- a/opa/test/README.md
+++ b/opa/test/README.md
@@ -1,0 +1,68 @@
+# opa-test
+
+Runs `opa test` against a Rego directory (or file), capturing both test
+results and coverage as JSON files for downstream consumption. Fails the step
+on any failing tests. Coverage capture is best-effort and does not affect step
+outcome on its own.
+
+## Prerequisites
+
+OPA must already be installed on the runner. Set it up earlier in the workflow
+with [`open-policy-agent/setup-opa`](https://github.com/open-policy-agent/setup-opa).
+
+## Inputs
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `test-path` | yes | Path to the Rego directory (or file) to test. Resolves relative to the workspace. |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `results-file` | Path of the test results JSON (always `opa-test-results.json` in the workspace). |
+| `coverage-file` | Path of the coverage JSON (always `opa-coverage.json` in the workspace). |
+| `exit-code` | `opa test` exit code as a string. `"0"` means all tests passed. |
+
+Both files are written in the formats OPA emits when called with
+`--format=json` (results) and `--coverage --format=json` (coverage).
+
+## Behavior
+
+- A missing path fails fast with a clear error.
+- OPA quirk: passing `--coverage` together with `--format=json` *replaces* the
+  test-result JSON with a coverage-only JSON. To capture both, this action runs
+  `opa test` twice. The first run determines step success; the second is
+  best-effort and never fails the step on its own.
+- `--fail-on-empty` is passed so a run where no tests were discovered counts as
+  a failure (catches typos in `test-path` and missing test files).
+- Per-test status and overall coverage are echoed to the job log as the run
+  progresses, before the JSON files are read by a later summary step.
+- On failures the action mirrors the non-zero exit code as a step failure via
+  `core.setFailed`. Use `if: always()` on summary steps that should still render.
+
+## Example
+
+```yaml
+- uses: open-policy-agent/setup-opa@<sha>
+- uses: kartverket/actions/opa/opa-test@<sha>
+  with:
+    test-path: policies
+```
+
+Reading the outputs in a later step:
+
+```yaml
+- uses: kartverket/actions/opa/opa-test@<sha>
+  id: test
+  with:
+    test-path: policies
+
+- if: always()
+  uses: actions/upload-artifact@<sha>
+  with:
+    name: opa-test-results
+    path: |
+      ${{ steps.test.outputs.results-file }}
+      ${{ steps.test.outputs.coverage-file }}
+```

--- a/opa/test/action.yml
+++ b/opa/test/action.yml
@@ -1,0 +1,85 @@
+name: 'OPA Test'
+description: |
+  Runs `opa test` against a Rego directory (or file), capturing both test
+  results and coverage as JSON files for downstream consumption, writes a step
+  summary, and fails the step on any failing tests. Coverage capture is
+  best-effort and does not affect step outcome on its own.
+
+  Prerequisite: OPA must already be installed on the runner. Use
+  `open-policy-agent/setup-opa` in the calling workflow before this action.
+
+inputs:
+  test-path:
+    description: |
+      Path to the Rego directory (or file) to test. Resolves relative to the
+      workspace.
+    required: true
+
+outputs:
+  results-file:
+    description: 'Path of the test results JSON written to the workspace.'
+    value: 'opa-test-results.json'
+  coverage-file:
+    description: 'Path of the coverage JSON written to the workspace.'
+    value: 'opa-coverage.json'
+  exit-code:
+    description: '`opa test` exit code (0 = all passed).'
+    value: ${{ steps.test.outputs.exit-code }}
+
+runs:
+  using: composite
+  steps:
+    - id: test
+      name: Run opa test
+      shell: bash
+      env:
+        TEST_PATH: ${{ inputs.test-path }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! -e "$TEST_PATH" ]]; then
+          echo "::error::test-path does not exist: $TEST_PATH"
+          exit 1
+        fi
+
+        # OPA quirk: passing `--coverage` together with `--format=json` REPLACES
+        # the test-result JSON with a coverage-only JSON. To capture both, we
+        # have to invoke `opa test` twice (plus a third run in default format
+        # to print readable output to the job log + capture for the summary).
+        # The first run determines step success; the others are best-effort and
+        # never fail the step. `bash -e` would abort on the first non-zero exit,
+        # so we capture exit codes via `||` instead.
+        TEST_EXIT=0
+        opa test --fail-on-empty --format=json "$TEST_PATH" \
+          > opa-test-results.json || TEST_EXIT=$?
+        opa test --coverage --format=json "$TEST_PATH" \
+          > opa-coverage.json || true
+
+        # Stream readable output to the log live AND capture to a file so the
+        # summary step can embed it. `--coverage` adds a coverage section at the
+        # end of the report.
+        opa test --fail-on-empty --coverage "$TEST_PATH" 2>&1 \
+          | tee opa-test-output.txt || true
+
+        echo "exit-code=$TEST_EXIT" >> "$GITHUB_OUTPUT"
+
+        if [[ "$TEST_EXIT" -ne 0 ]]; then
+          echo "::error::opa test failed (exit $TEST_EXIT)."
+          exit "$TEST_EXIT"
+        fi
+
+    - name: Write step summary
+      if: always()
+      shell: bash
+      run: |
+        {
+          echo "## OPA test"
+          echo ""
+          if [[ -f opa-test-output.txt ]]; then
+            echo '```'
+            cat opa-test-output.txt
+            echo '```'
+          else
+            echo "_Tests did not run._"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/opa/test/testdata/failing/policy.rego
+++ b/opa/test/testdata/failing/policy.rego
@@ -1,0 +1,5 @@
+package example
+
+default allow := false
+
+allow if input.user == "alice"

--- a/opa/test/testdata/failing/policy_test.rego
+++ b/opa/test/testdata/failing/policy_test.rego
@@ -1,0 +1,8 @@
+package example_test
+
+import data.example
+
+# This test asserts the opposite of what the policy does — it expects alice to
+# be denied, but the policy allows her. Used by the test workflow to verify the
+# action correctly fails when tests fail.
+test_alice_denied if not example.allow with input as {"user": "alice"}

--- a/opa/test/testdata/passing/policy.rego
+++ b/opa/test/testdata/passing/policy.rego
@@ -1,0 +1,10 @@
+package example
+
+default allow := false
+
+allow if input.user == "alice"
+
+allow if {
+    input.user == "bob"
+    input.method == "GET"
+}

--- a/opa/test/testdata/passing/policy_test.rego
+++ b/opa/test/testdata/passing/policy_test.rego
@@ -1,0 +1,11 @@
+package example_test
+
+import data.example
+
+test_alice_allowed if example.allow with input as {"user": "alice"}
+
+test_bob_get_allowed if example.allow with input as {"user": "bob", "method": "GET"}
+
+test_bob_post_denied if not example.allow with input as {"user": "bob", "method": "POST"}
+
+test_stranger_denied if not example.allow with input as {"user": "eve"}


### PR DESCRIPTION
Set up composite actions for actinos regarding OPA policies. Three actions are createad:
- kartverket/actions/opa/build-push: Builds an OPA bundle and pushes it to a artifact registry.
- kartverket/actions/opa/lint: Lints the OPA policies with [Regal](https://www.openpolicyagent.org/projects/regal).
- kartverket/actions/opa/test: Tests the OPA policies.

Also added a workflow to test that these actions behave as expected given happy-case input and failing-case input.