### PR TITLE
Extend opa/lint action to take regal config file as input

### DIFF
--- a/.github/workflows/test-opa.yml
+++ b/.github/workflows/test-opa.yml
@@ -138,6 +138,84 @@ jobs:
             exit 1
           fi
 
+  # Lints the 'clean_with_data' together with regal config file. Should succeed.
+  lint-clean-with-data-and-config:
+    name: 'lint: clean_with_data with Regal config pass'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: lint
+        uses: ./opa/lint
+        with:
+          path: opa/lint/testdata/clean_with_data
+          # Skip Code Scanning upload in CI — this workflow only verifies the
+          # action's local behaviour, not the upload integration.
+          upload-sarif: 'false'
+          config-file: opa/lint/testdata/clean_with_data/regal-config.yaml
+
+      - name: Verify SARIF report has no findings
+        env:
+          OUTCOME: ${{ steps.lint.outcome }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$OUTCOME" != "success" ]]; then
+            echo "::error::Expected lint step to succeed, got outcome '$OUTCOME'"
+            exit 1
+          fi
+          if [[ ! -f regal-results.sarif ]]; then
+            echo "::error::regal-results.sarif was not produced"
+            exit 1
+          fi
+
+          # SARIF places findings under `.runs[0].results`.
+          results=$(jq '.runs[0].results | length' regal-results.sarif)
+          if [[ "$results" != "0" ]]; then
+            echo "::error::Expected 0 SARIF results, got $results"
+            jq '.runs[0].results' regal-results.sarif
+            exit 1
+          fi
+
+  # Lints the 'clean_with_data' together without regal config file. Should fail
+  # as a config is needed to correctly resolve the linting error for unresolved-reference.
+  lint-clean-with-data-without-config:
+    name: 'lint: clean_with_data without Regal config failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: lint
+        uses: ./opa/lint
+        continue-on-error: true
+        with:
+          path: opa/lint/testdata/clean_with_data
+          # Skip Code Scanning upload in CI — this workflow only verifies the
+          # action's local behaviour, not the upload integration.
+          upload-sarif: 'false'
+
+      - name: Verify the lint step failed and recorded violations
+        env:
+          OUTCOME: ${{ steps.lint.outcome }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected lint step to fail, got outcome '$OUTCOME'"
+            exit 1
+          fi
+          if [[ ! -f regal-results.sarif ]]; then
+            echo "::error::regal-results.sarif was not produced"
+            exit 1
+          fi
+
+          results=$(jq '.runs[0].results | length' regal-results.sarif)
+          if (( results < 1 )); then
+            echo "::error::Expected at least one SARIF result, got $results"
+            exit 1
+          fi
+          echo "Recorded $results SARIF result(s) as expected."
+
   # Lints the `violations` testdata fixture (deliberately badly-formatted Rego)
   # — should fail with a non-zero exit code and report at least one SARIF
   # finding.

--- a/opa/lint/README.md
+++ b/opa/lint/README.md
@@ -19,10 +19,11 @@ additionally need GitHub Advanced Security (GHAS).
 
 ## Inputs
 
-| Name | Required | Default | Description |
-|------|----------|---------|-------------|
-| `path` | yes |  | Path to the Rego directory (or file) to lint. Resolves relative to the workspace. |
-| `upload-sarif` | no | `'true'` | Whether to upload the SARIF report to GitHub Code Scanning. Set to `'false'` for repos without GHAS or when you don't want findings posted to the Security tab. |
+| Name           | Required | Default  | Description                                                                                                                                                     |
+|----------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `path`         | yes      |          | Path to the Rego directory (or file) to lint. Resolves relative to the workspace.                                                                               |
+| `upload-sarif` | no       | `'true'` | Whether to upload the SARIF report to GitHub Code Scanning. Set to `'false'` for repos without GHAS or when you don't want findings posted to the Security tab. |
+| `config-file`  | no       |          | Path to the Regal config file to use when linting.                                                                                                              |
 
 ## Outputs
 

--- a/opa/lint/action.yml
+++ b/opa/lint/action.yml
@@ -20,6 +20,12 @@ inputs:
       permissions. Set to `'false'` to skip the upload.
     required: false
     default: 'true'
+  config-file:
+    description:  |
+      Path to the Regal config file used when linting with Regal. Resolves 
+      relative to the workspace.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -45,6 +51,7 @@ runs:
       name: Run Regal
       shell: bash
       env:
+        CONFIG_FILE: ${{ inputs.config-file }}
         REGO_PATH: ${{ inputs.path }}
         # Disable ANSI color codes so the captured output (regal-output.txt) is
         # plain text — otherwise the step summary renders escape sequences as
@@ -65,8 +72,14 @@ runs:
         # `bash -e` would abort on the first non-zero exit, so we capture the
         # exit code via `||` instead.
         LINT_EXIT=0
-        regal lint --format sarif "$REGO_PATH" > regal-results.sarif || LINT_EXIT=$?
-        regal lint "$REGO_PATH" 2>&1 | tee regal-output.txt || true
+        
+        REGAL_CONFIG_FLAG=""
+        if [ -n "$CONFIG_FILE" ]; then
+          REGAL_CONFIG_FLAG="--config-file $CONFIG_FILE"
+        fi
+        
+        regal lint --format sarif $REGAL_CONFIG_FLAG "$REGO_PATH" > regal-results.sarif || LINT_EXIT=$?
+        regal lint $REGAL_CONFIG_FLAG "$REGO_PATH" 2>&1 | tee regal-output.txt || true
 
         echo "exit-code=$LINT_EXIT" >> "$GITHUB_OUTPUT"
 

--- a/opa/lint/testdata/clean_with_data/permissions/data.json
+++ b/opa/lint/testdata/clean_with_data/permissions/data.json
@@ -1,0 +1,4 @@
+{
+  "Alice": "read",
+  "Bob": "write"
+}

--- a/opa/lint/testdata/clean_with_data/policy.rego
+++ b/opa/lint/testdata/clean_with_data/policy.rego
@@ -1,0 +1,12 @@
+package clean_with_data
+
+import rego.v1
+
+default allow := false
+
+# METADATA
+# entrypoint: true
+allow if {
+	role := data.permissions[input.name]
+	role == input.role
+}

--- a/opa/lint/testdata/clean_with_data/policy_test.rego
+++ b/opa/lint/testdata/clean_with_data/policy_test.rego
@@ -1,0 +1,5 @@
+package clean_with_data_test
+
+test_alice_read_returns_true if {
+	data.clean_with_data.allow with input as {"name": "Alice", "role": "read"}
+}

--- a/opa/lint/testdata/clean_with_data/regal-config.yaml
+++ b/opa/lint/testdata/clean_with_data/regal-config.yaml
@@ -1,0 +1,6 @@
+rules:
+  imports:
+    unresolved-reference:
+      level: error
+      except-paths:
+        - data.permissions


### PR DESCRIPTION
A Regal config file is in some cases required / strongly needed to handle linting failures in a gracefully manner. We therefore extend opa/lint action with `config-file` as an optional input.