### PR TITLE
Explicitly set oci image config mediatype in oras push

### DIFF
--- a/opa/build-push/action.yml
+++ b/opa/build-push/action.yml
@@ -165,6 +165,8 @@ runs:
           # (`...:tag1,tag2`) and applies all of them to the same manifest.
           tag_list=$(IFS=','; echo "${all_tags[*]}")
           digest=$(oras push "${ARTIFACT_NAME}:${tag_list}" \
+            --artifact-type "application/vnd.cncf.openpolicyagent.config.v1+json" \
+            --config /dev/null:application/vnd.oci.image.config.v1+json \
             bundle.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip \
             --format json | jq -r '.digest')
         fi


### PR DESCRIPTION
OPA gets a 404 Not Found when fetching bundles directly from ghcr.io. This is because oras default to an unknown artifact type (`application/vnd.unknown.artifact.v1`) which breaks OPA's requirements. This PR fixes this by overriding the artifact type `application/vnd.oci.image.config.v1+json`.